### PR TITLE
[TC-2153] add to default role read access to variants

### DIFF
--- a/lib/tasks/populate.rake
+++ b/lib/tasks/populate.rake
@@ -128,8 +128,9 @@ namespace :spree_roles do
     desc "Create admin username and password"
     task populate: :environment do
       default_permission = make_permission('default-permissions', 0)
+      read_variant_permission = make_permission('can-read-spree/variants', 0)
       default_permission_set = make_permission_set(
-        [default_permission],
+        [default_permission, read_variant_permission],
         'default',
         'Permission for general users including the customers, Note: *users without this permission cannot checkout*'
       )


### PR DESCRIPTION
UPD! Logic is moved to tc-shop codebase (https://github.com/TerraCycleUS/tc-shop/pull/124) as per Adam`s request 

Add as default permission to read variant, in order to have guest checkout flow working automatically from seeds