### PR TITLE
users can now manage their addresses

### DIFF
--- a/lib/spree/permissions.rb
+++ b/lib/spree/permissions.rb
@@ -32,9 +32,8 @@ module Spree
         !order.completed? && (order.user == user || order&.token == token)
       end
 
-      current_ability.can :read, Spree::Address do |address|
-        address.user == user
-      end
+      current_ability.can [:manage], Spree::Address, { user_id: user.id }
+      
       current_ability.can [:read], Spree::State
       current_ability.can [:read], Spree::Country
     end


### PR DESCRIPTION
This is a fix for spree 4.1 so that users can manage their addresses. Adding new one, or modifying existing ones in their /account page.